### PR TITLE
use h901

### DIFF
--- a/pplus.mk
+++ b/pplus.mk
@@ -33,7 +33,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     device/lge/pplus/kernel:kernel
 
-PRODUCT_NAME := pplus
+PRODUCT_NAME := h901
 PRODUCT_DEVICE := pplus
 PRODUCT_BRAND := LG
 PRODUCT_MODEL := V10


### PR DESCRIPTION
it's the only devices to be unlocked and it will need one tree per variant so use h901 instead of pplus
